### PR TITLE
fix client homepage view all products redirect

### DIFF
--- a/src/app/(customerFacing)/page.tsx
+++ b/src/app/(customerFacing)/page.tsx
@@ -51,7 +51,7 @@ function ProductGridSection ({title, productsFetcher}: ProductGridSectionProps) 
         <div className="flex gap-4">
             <h2 className="text-3xl font-bold">{title}</h2>
             <Button variant="outline" asChild>
-                <Link href="/prducts" className="space-x-2">
+                <Link href="/products" className="space-x-2">
                     <span>View All</span>
                     <ArrowRight className="size-4" />
                 </Link>


### PR DESCRIPTION
This PR addresses an issue with redirecting users to products page when clicking home page view all buttons.